### PR TITLE
Bug fixes

### DIFF
--- a/mipdb/tables.py
+++ b/mipdb/tables.py
@@ -13,7 +13,7 @@ from mipdb.database import METADATA_TABLE
 from mipdb.dataelements import CommonDataElement
 from mipdb.exceptions import UserInputError
 from mipdb.schema import Schema
-RECORDS_PER_COPY = 1000000
+RECORDS_PER_COPY = 100000
 
 
 class User(Enum):
@@ -433,7 +433,6 @@ class TemporaryTable(Table):
         records=None,
         offset=2,
     ):
-
         self._validate_csv_contains_eof(csv_path=csv_path)
         db.copy_csv_in_table(
             file_location=csv_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mipdb"
-version = "2.0.1"
+version = "2.0.2"
 description = ""
 authors = ["Your Name <you@example.com>"]
 

--- a/tests/data/success/data_model_v_1_0/CDEsMetadata.json
+++ b/tests/data/success/data_model_v_1_0/CDEsMetadata.json
@@ -39,7 +39,8 @@
                 "enumerations": [
                     {"code": "dataset", "label": "Dataset"},
                     {"code": "dataset1", "label": "Dataset 1"},
-                    {"code": "dataset2", "label": "Dataset 2"}
+                    {"code": "dataset2", "label": "Dataset 2"},
+                    {"code": "dataset10", "label": "Dataset 10"}
                 ],
                 "label": "Dataset",
                 "methodology": ""

--- a/tests/data/success/data_model_v_1_0/dataset10.csv
+++ b/tests/data/success/data_model_v_1_0/dataset10.csv
@@ -1,0 +1,6 @@
+subjectcode,var1,var3,dataset
+2,1,,dataset10
+2,2,22,dataset10
+2,1,23,dataset10
+5,1,24,dataset10
+5,2,25,dataset2

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -188,6 +188,44 @@ def test_add_dataset(db):
 
 @pytest.mark.database
 @pytest.mark.usefixtures("monetdb_container", "cleanup_db")
+def test_add_two_datasets_with_same_name_different_data_model(db):
+    # Setup
+    runner = CliRunner()
+
+    # Check dataset not present already
+    runner.invoke(init, DEFAULT_OPTIONS)
+    runner.invoke(add_data_model, [DATA_MODEL_FILE] + DEFAULT_OPTIONS)
+    runner.invoke(add_data_model, ["tests/data/success/data_model1_v_1_0/CDEsMetadata.json"] + DEFAULT_OPTIONS)
+
+    # Test
+    result = runner.invoke(
+        add_dataset,
+        [
+            ABSOLUTE_PATH_SUCCESS_DATA_FOLDER + "/data_model_v_1_0/dataset10.csv",
+            "--data-model",
+            "data_model",
+            "-v",
+            "1.0",
+        ]
+        + DEFAULT_OPTIONS,
+    )
+    result = runner.invoke(
+        add_dataset,
+        [
+            ABSOLUTE_PATH_SUCCESS_DATA_FOLDER + "/data_model1_v_1_0/dataset10.csv",
+            "--data-model",
+            "data_model1",
+            "-v",
+            "1.0",
+        ]
+        + DEFAULT_OPTIONS,
+    )
+    assert result.exit_code == ExitCode.OK
+    assert [(1, 'dataset10'), (2, 'dataset10')] == db.get_values(columns=["data_model_id", "code"])
+
+
+@pytest.mark.database
+@pytest.mark.usefixtures("monetdb_container", "cleanup_db")
 def test_validate_dataset_with_volume(db):
     # Setup
     runner = CliRunner()


### PR DESCRIPTION
Now the csv importation without sockets properly adds all columns not only the first 100000.
Validation without sockets is now in batches of 100000 records to avoid the memory spike. Now if two datasets have the same name but different data model they are properly added in the system table for datasets.